### PR TITLE
hs:scan:listでディレクトリを除外できるように改善

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,23 @@ Display updated time of files in target directory(Including subdirectories).
 ```shell
 $ php console.php hs:scan:update {{target_directory}}
 ```
+
+# Exclude the directory
+
+```sql
+$ php console.php hs:scan:list {{target_directory}} -e {{excluded_directories}}.yml
+```
+
+## Sample
+
+```shell
+$ php console.php hs:scan:list vendor -e exclusion.yml
+````
+
+```yml
+# exclusion.yml
+- "vendor/bin"
+- "vendor/doctrine"
+- "vendor/composer"
+- "vendor/symfony"
+```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "description": "Script to scan directories made symfony4 console command.",
     "type": "symfony/console",
     "require": {
-        "symfony/console": "^4.2"
+        "symfony/console": "^4.2",
+        "symfony/event-dispatcher": "^4.2",
+        "symfony/yaml": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"

--- a/console.php
+++ b/console.php
@@ -3,12 +3,13 @@ require __DIR__ . '/vendor/autoload.php';
 
 use Symfony\Component\Console\Application;
 
-$fileScan        = new \HS\Scan\Services\FileScan();
-$fileCountScan   = new \HS\Scan\Services\FileCountScan();
-$updatedFileScan = new \HS\Scan\Services\UpdatedFileScan();
+$dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+$fileScan        = new \HS\Scan\Services\FileScan($dispatcher);
+$fileCountScan   = new \HS\Scan\Services\FileCountScan($dispatcher);
+$updatedFileScan = new \HS\Scan\Services\UpdatedFileScan($dispatcher);
 
 $application = new Application('hs-scan', '0.0.1');
-$application->add(new \HS\Scan\Command\FileScanCommand($fileScan));
+$application->add(new \HS\Scan\Command\FileScanCommand($fileScan, $dispatcher));
 $application->add(new \HS\Scan\Command\FileCountScanCommand($fileCountScan));
 $application->add(new \HS\Scan\Command\UpdatedFileScanCommand($updatedFileScan));
 try {

--- a/src/Command/FileScanCommand.php
+++ b/src/Command/FileScanCommand.php
@@ -3,20 +3,27 @@
 namespace HS\Scan\Command;
 
 use HS\Scan\Services\AbstractScan;
+use HS\Scan\Event\ExclusionEvent;
+use HS\Scan\EventListener\ExclusionListener;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Yaml\Yaml;
 
 class FileScanCommand extends Command
 {
     const COMMAND_NAME = 'hs:scan:list';
 
     private $scan;
+    private $dispatcher;
 
-    public function __construct(AbstractScan $scan)
+    public function __construct(AbstractScan $scan, EventDispatcher $dispatcher)
     {
         $this->scan = $scan;
+        $this->dispatcher = $dispatcher;
         parent::__construct(self::COMMAND_NAME);
     }
 
@@ -25,7 +32,8 @@ class FileScanCommand extends Command
         $this
             ->setName('hs:scan:list')
             ->setDescription('Display files list in directory(Including subdirectories)')
-            ->addArgument('directory', InputArgument::REQUIRED, 'Relative directory path from console.php', null);
+            ->addArgument('directory', InputArgument::REQUIRED, 'Relative directory path from console.php', null)
+            ->addOption('exclusion', 'e', InputOption::VALUE_OPTIONAL, 'Yaml file that is Relative path of excluded directories path from console.php', null);
     }
 
     /**
@@ -34,6 +42,13 @@ class FileScanCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $exclusionDirectories = $input->getOption('exclusion');
+        if ($exclusionDirectories) {
+            $exclusionDirectories = Yaml::parseFile($exclusionDirectories);
+            $listener             = new ExclusionListener();
+            $listener->addDirectories($exclusionDirectories);
+            $this->dispatcher->addListener(ExclusionEvent::NAME, [$listener, 'onExcludeAction']);
+        }
         $out = $this->scan->execute($input->getArgument('directory'));
         $output->writeln($out);
     }

--- a/src/Event/ExclusionEvent.php
+++ b/src/Event/ExclusionEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace HS\Scan\Event;
+
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ExclusionEvent extends Event
+{
+    const NAME = 'directory.exclusion';
+
+    private $directory;
+    private $isExclusion = false;
+
+    public function __construct($directory)
+    {
+        $this->directory = $directory;
+    }
+
+    public function getDirectory()
+    {
+        return $this->directory;
+    }
+
+    function setIsExclusion(bool $value)
+    {
+        $this->isExclusion = $value;
+    }
+    
+    public function isExcluded() {
+    
+    return  $this->isExclusion;
+    }
+}

--- a/src/EventListener/ExclusionListener.php
+++ b/src/EventListener/ExclusionListener.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace HS\Scan\EventListener;
+
+use Symfony\Component\EventDispatcher\Event;
+
+class ExclusionListener
+{
+    private $directories = [];
+
+    public function addDirectories(array $directory)
+    {
+        $this->directories = $directory;
+    }
+
+    public function onExcludeAction(Event $event)
+    {
+        $targetDirectory = $event->getDirectory();
+        foreach ($this->directories as $directory) {
+            if ($directory === $targetDirectory) {
+                $event->setIsExclusion(true);
+                break;
+            }
+        }
+    }
+}

--- a/src/Services/AbstractScan.php
+++ b/src/Services/AbstractScan.php
@@ -4,9 +4,18 @@
 namespace HS\Scan\Services;
 
 
+use HS\Scan\Event\ExclusionEvent;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
 abstract class AbstractScan
 {
     protected $list;
+    protected $dispatcher;
+    
+    public function __construct(EventDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
 
     /**
      * @param string $directory
@@ -24,6 +33,11 @@ abstract class AbstractScan
             $path = rtrim($directory, '/').'/'.$file;
             if (is_file($path)) {
                 $this->list[] = $path;
+                continue;
+            }
+            $event = new ExclusionEvent($path);
+            $this->dispatcher->dispatch(ExclusionEvent::NAME, $event);
+            if ($event->isExcluded()) {
                 continue;
             }
             $this->scan($path);

--- a/src/Services/FileCountScan.php
+++ b/src/Services/FileCountScan.php
@@ -3,7 +3,6 @@
 
 namespace HS\Scan\Services;
 
-
 class FileCountScan extends AbstractScan
 {
 

--- a/src/Services/FileScan.php
+++ b/src/Services/FileScan.php
@@ -12,7 +12,6 @@ class FileScan extends AbstractScan
      */
     public function execute(string $directory = null): array
     {
-
         return $this->getFiles($directory);
     }
 }


### PR DESCRIPTION
Yamlファイルに除外したいディレクトリを列挙して、hs:scan:listのeオプションへYamlファイルのパスを渡す